### PR TITLE
handle indented heredoc syntax

### DIFF
--- a/syntaxes/hcl.json
+++ b/syntaxes/hcl.json
@@ -255,7 +255,7 @@
             "patterns" : [
                 {
                     "comment" : "Heredoc string",
-                    "begin": "<<(\\w+)",
+                    "begin": "<<-?(\\w+)",
                     "beginCaptures": {
                         "0": { "name": "entity.name.section" }
                     },


### PR DESCRIPTION
HCL allows indented heredoc with `<<-MARK` syntax, which strips the same amount of leading whitespace from all lines as what the end `MARK` line contains. At least in theory. Nevertheless, this is valid syntax.